### PR TITLE
Coroutines 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlin_version = '1.3.41'
+        kotlin_version = '1.3.50'
         japicmp_version = '0.2.8'
     }
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         japicmp_version = '0.2.8'
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0-alpha06'
+        classpath 'com.android.tools.build:gradle:3.6.0-alpha09'
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18"

--- a/compatibility.gradle
+++ b/compatibility.gradle
@@ -48,6 +48,16 @@ subprojects { subproject ->
                 }
             }.artifacts.artifactFiles
 
+            // Explicitly exclude Kotlin internal classes:
+            classExcludes = [
+                    'drewhamilton.preferoutines.CoroutineAllPreferenceListener',
+                    'drewhamilton.preferoutines.CoroutinePreferenceListener',
+                    'drewhamilton.preferoutines.CoroutineSinglePreferenceChangeListener',
+                    'drewhamilton.preferoutines.CoroutineSinglePreferenceContainsListener',
+                    'drewhamilton.preferoutines.CoroutineSinglePreferenceListener',
+                    'drewhamilton.preferoutines.SinglePreferenceListener'
+            ]
+
             onlyBinaryIncompatibleModified true
             failOnModification failIfIncompatible
             txtOutputFile = file("$buildDir/reports/japi.txt")

--- a/compatibility.gradle
+++ b/compatibility.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 def compatibleVersion = '0.3.0'
-def failIfIncompatible = true
+def failIfIncompatible = false
 subprojects { subproject ->
     afterEvaluate {
         if (!subproject.hasProperty('artifact'))

--- a/extras/src/main/java/drewhamilton/preferoutines/extras/PreferoutinesExtras.kt
+++ b/extras/src/main/java/drewhamilton/preferoutines/extras/PreferoutinesExtras.kt
@@ -3,7 +3,7 @@ package drewhamilton.preferoutines.extras
 import android.content.SharedPreferences
 import drewhamilton.preferoutines.getStringFlow
 import drewhamilton.preferoutines.getStringSetFlow
-import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -36,7 +36,7 @@ inline fun <reified E : Enum<E>> SharedPreferences.getEnum(key: String, defaultV
  * [defaultValue] is emitted.
  * @throws ClassCastException if there is a preference with this name that is not a String.
  */
-@FlowPreview
+@ExperimentalCoroutinesApi
 fun SharedPreferences.getNonNullStringFlow(key: String, defaultValue: String): Flow<String> =
     getStringFlow(key, defaultValue)
         .map { it!! }
@@ -50,7 +50,7 @@ fun SharedPreferences.getNonNullStringFlow(key: String, defaultValue: String): F
  * [defaultValue] is emitted.
  * @throws ClassCastException if there is a preference with this name that is not a {@link Set}.
  */
-@FlowPreview
+@ExperimentalCoroutinesApi
 fun SharedPreferences.getNonNullStringSetFlow(key: String, defaultValue: Set<String>): Flow<Set<String>> =
     getStringSetFlow(key, defaultValue)
         .map { it!! }
@@ -63,7 +63,7 @@ fun SharedPreferences.getNonNullStringSetFlow(key: String, defaultValue: Set<Str
  * [defaultValue] is emitted.
  * @throws ClassCastException if there is a preference with this name that is not a String.
  */
-@FlowPreview
+@ExperimentalCoroutinesApi
 inline fun <reified E : Enum<E>> SharedPreferences.getEnumFlow(key: String, defaultValue: E?): Flow<E?> =
     getStringFlow(key, defaultValue?.name)
         .map { name ->
@@ -79,7 +79,7 @@ inline fun <reified E : Enum<E>> SharedPreferences.getEnumFlow(key: String, defa
  * [defaultValue] is emitted.
  * @throws ClassCastException if there is a preference with this name that is not a String.
  */
-@FlowPreview
+@ExperimentalCoroutinesApi
 inline fun <reified E : Enum<E>> SharedPreferences.getNonNullEnumFlow(key: String, defaultValue: E): Flow<E> =
     getEnumFlow(key, defaultValue)
         .map { it!! }

--- a/preferoutines/build.gradle
+++ b/preferoutines/build.gradle
@@ -60,7 +60,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0-RC2'
+    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-inline:2.28.2'

--- a/preferoutines/build.gradle
+++ b/preferoutines/build.gradle
@@ -60,7 +60,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.2'
+    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0-RC2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-inline:2.28.2'

--- a/preferoutines/src/main/java/drewhamilton/preferoutines/CoroutineAllPreferenceListener.kt
+++ b/preferoutines/src/main/java/drewhamilton/preferoutines/CoroutineAllPreferenceListener.kt
@@ -1,10 +1,12 @@
 package drewhamilton.preferoutines
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.ProducerScope
 
+@ExperimentalCoroutinesApi
 internal class CoroutineAllPreferenceListener(
-    override val channel: SendChannel<Map<String, *>>
+    override val channel: ProducerScope<Map<String, *>>
 ) : CoroutinePreferenceListener<Map<String, *>> {
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {

--- a/preferoutines/src/main/java/drewhamilton/preferoutines/CoroutinePreferenceListener.kt
+++ b/preferoutines/src/main/java/drewhamilton/preferoutines/CoroutinePreferenceListener.kt
@@ -1,9 +1,11 @@
 package drewhamilton.preferoutines
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.ProducerScope
 
 internal interface CoroutinePreferenceListener<T> : SharedPreferences.OnSharedPreferenceChangeListener {
 
-    val channel: SendChannel<T>
+    @ExperimentalCoroutinesApi
+    val channel: ProducerScope<T>
 }

--- a/preferoutines/src/main/java/drewhamilton/preferoutines/CoroutineSinglePreferenceChangeListener.kt
+++ b/preferoutines/src/main/java/drewhamilton/preferoutines/CoroutineSinglePreferenceChangeListener.kt
@@ -1,12 +1,13 @@
 package drewhamilton.preferoutines
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.ProducerScope
 
+@ExperimentalCoroutinesApi
 internal class CoroutineSinglePreferenceChangeListener<T> constructor(
     key: String,
-    channel: SendChannel<T>,
+    channel: ProducerScope<T>,
     private val defaultValue: T,
     private inline val getPreference: SharedPreferences.(String, T) -> T
 ) : CoroutineSinglePreferenceListener<T>(key, channel) {

--- a/preferoutines/src/main/java/drewhamilton/preferoutines/CoroutineSinglePreferenceContainsListener.kt
+++ b/preferoutines/src/main/java/drewhamilton/preferoutines/CoroutineSinglePreferenceContainsListener.kt
@@ -1,12 +1,13 @@
 package drewhamilton.preferoutines
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.ProducerScope
 
+@ExperimentalCoroutinesApi
 internal class CoroutineSinglePreferenceContainsListener constructor(
     key: String,
-    channel: SendChannel<Boolean>
+    channel: ProducerScope<Boolean>
 ) : CoroutineSinglePreferenceListener<Boolean>(key, channel) {
 
     override fun SharedPreferences.getCurrentValue() = contains(key)

--- a/preferoutines/src/main/java/drewhamilton/preferoutines/CoroutineSinglePreferenceListener.kt
+++ b/preferoutines/src/main/java/drewhamilton/preferoutines/CoroutineSinglePreferenceListener.kt
@@ -1,11 +1,13 @@
 package drewhamilton.preferoutines
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.ProducerScope
 
+@ExperimentalCoroutinesApi
 internal abstract class CoroutineSinglePreferenceListener<T> constructor(
     key: String,
-    override val channel: SendChannel<T>
+    override val channel: ProducerScope<T>
 ) : SinglePreferenceListener(key), CoroutinePreferenceListener<T> {
 
     final override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences) {


### PR DESCRIPTION
Using `callbackFlow` instead of `flowViaChannel`.

To be merged when coroutines 1.3.0 is released as stable.